### PR TITLE
Fix Help String Format for Python 2.6

### DIFF
--- a/pystuck/__init__.py
+++ b/pystuck/__init__.py
@@ -27,8 +27,8 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description=README)
-    parser.add_argument('--host', default=DEFAULT_HOST, help='server address (default: {})'.format(DEFAULT_HOST))
-    parser.add_argument('--port', default=DEFAULT_PORT, type=int, help='server port (default: {})'.format(DEFAULT_PORT))
+    parser.add_argument('--host', default=DEFAULT_HOST, help='server address (default: {0})'.format(DEFAULT_HOST))
+    parser.add_argument('--port', default=DEFAULT_PORT, type=int, help='server port (default: {0})'.format(DEFAULT_PORT))
     parser.add_argument('--unix_socket', default=None, help='server unix domain socket')
     parser.add_argument('--no-stacks', action='store_false', dest='stacks', help="don't print the debugee's threads/greenlets")
     parser.add_argument('--exclude-greenlets', action='store_false', dest='greenlets', help="don't print the debugee's greenlets. pass it when the process hogs memory as printing greenlets requires traversal of all objects in the garbage collector")

--- a/pystuck/thread_probe.py
+++ b/pystuck/thread_probe.py
@@ -35,7 +35,7 @@ def pretty_format_stack(frame):
 def stacks_repr_generator(threads=True, greenlets=True):
     for thread, frame in chain(thread_frame_generator() if threads else (),
                                greenlet_frame_generator() if greenlets else ()):
-        yield "{}\n{}".format(thread, pretty_format_stack(frame))
+        yield "{0}\n{1}".format(thread, pretty_format_stack(frame))
 
 def stacks_repr(*a, **k):
     return '\n'.join(stacks_repr_generator(*a, **k))


### PR DESCRIPTION
Hi,

This looked like a useful tool for a problem I was having, so I checked it out. 

My dev server is running Debian, so I only have Python 2.6. It turns out that the format string syntax used in the help strings is not compatible with Python 2.6 (2.6 requires the indices of arguments to be indicated). I fixed this locally, and I thought you might like to fix it in your code in case others have the same problem.

Thanks for this tool!
Brad Reaves
