### PR TITLE
Port to latest rpyc

### DIFF
--- a/pystuck/__init__.py
+++ b/pystuck/__init__.py
@@ -1,44 +1,70 @@
-import socket
-from pystuck.rpyc_tools import run_server, DEFAULT_HOST, DEFAULT_PORT
-README = """
-pystuck.py is a utility for analyzing stuck python programs (or just hardcore debugging).
+"""
+pystuck is a utility for analyzing stuck python programs (or just hardcore
+debugging).
 
-in order to debug a python program (hence, the debugee),
+In order to debug a python program (hence, the debugee),
 add this line anywhere at startup: import pystuck; pystuck.run_server().
 
-this script is the client, once invoked it connects to the debuggee
+This script is the client, once invoked it connects to the debuggee
 and prints the debugee's threads stack traces (good for most cases).
-in addition, it opens an ipython prompt with an rpyc connection that provides
-access to the debuggee's modules (good for inspecting variables)."""
+In addition, it opens an ipython prompt with an rpyc connection that provides
+access to the debuggee's modules (good for inspecting variables).
+"""
+import socket
+from pystuck.rpyc_tools import run_server, DEFAULT_HOST, DEFAULT_PORT
 
-def run_client(host=DEFAULT_HOST, port=DEFAULT_PORT, unix_socket=None, stacks=True, ipython=True, greenlets=True):
-    from rpyc.utils.classic import connect, unix_connect
-    conn = connect(host=host, port=port) if unix_socket is None else unix_connect(unix_socket)
+
+def run_client(host=DEFAULT_HOST, port=DEFAULT_PORT, stacks=False, ipython=True,
+               greenlets=True):
+    from rpyc.utils.classic import connect
+    conn = connect(host=host, port=port)
     if stacks:
-        print (conn.modules['pystuck.thread_probe'].stacks_repr(greenlets=greenlets))
+        print(conn.modules['pystuck.thread_probe'].stacks_repr(
+            greenlets=greenlets))
     if ipython:
         from pystuck.ipython import ishell
         modules = conn.modules
-        print ("use the 'modules' dictionary to access remote modules (like 'os', or '__main__')")
-        ishell()
+        ishell(local_ns=locals())
+
 
 def main():
     import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
 
-    parser = argparse.ArgumentParser(description=README)
-    parser.add_argument('--host', default=DEFAULT_HOST, help='server address (default: {0})'.format(DEFAULT_HOST))
-    parser.add_argument('--port', default=DEFAULT_PORT, type=int, help='server port (default: {0})'.format(DEFAULT_PORT))
-    parser.add_argument('--unix_socket', default=None, help='server unix domain socket')
-    parser.add_argument('--no-stacks', action='store_false', dest='stacks', help="don't print the debugee's threads/greenlets")
-    parser.add_argument('--exclude-greenlets', action='store_false', dest='greenlets', help="don't print the debugee's greenlets. pass it when the process hogs memory as printing greenlets requires traversal of all objects in the garbage collector")
-    parser.add_argument('--no-ipython', action='store_false', dest='ipython', help="don't open an ipython prompt for debugging")
+    parser.add_argument(
+        '--host', default=DEFAULT_HOST,
+        help='server address (default: {0})'.format(DEFAULT_HOST)
+    )
+    parser.add_argument(
+        '--port', default=DEFAULT_PORT, type=int,
+        help='server port (default: {0})'.format(DEFAULT_PORT)
+    )
+    parser.add_argument(
+        '--stacks', action='store_true', dest='stacks',
+        help="Print all thread/greenlet stack traces on initial shell entry"
+    )
+    parser.add_argument(
+        '--exclude-greenlets', action='store_false',
+        dest='greenlets', help="don't print the debugee's greenlets. pass it "
+        "when the process hogs memory as printing greenlets requires traversal"
+        " of all objects in the garbage collector")
+    parser.add_argument(
+        '--no-ipython', action='store_false', dest='ipython',
+        help="don't open an ipython prompt for debugging"
+    )
     args = parser.parse_args()
+
+    if not args.ipython:
+        # if no shell then just print the bts
+        args.stacks = True
+        print("Printing all thread backtraces:\n")
 
     try:
         run_client(**vars(args))
     except socket.error:
-        print ("unable to connect to the server, please follow the instructions:")
-        print (README)
+        print("unable to connect to the server, please follow the "
+              "instructions:")
+        print(__doc__)
 
 if __name__ == '__main__':
     main()

--- a/pystuck/greenlets.py
+++ b/pystuck/greenlets.py
@@ -5,7 +5,7 @@ except ImportError:
 else:
     greenlet_available = True
     is_patched = False
-    
+
     from weakref import WeakSet
 
     orig_greenlet = greenlet.greenlet
@@ -15,7 +15,7 @@ else:
     class PatchedGreenlet(orig_greenlet):
         def __init__(self, *a, **k):
             super(PatchedGreenlet, self).__init__(*a, **k)
-            greenlets.add(self)        
+            greenlets.add(self)
 
     def patch():
         global is_patched
@@ -33,7 +33,7 @@ else:
 # thanks Tarek!
 def greenlets_from_memory():
     import gc
-    
+
     try:
         from greenlet import greenlet
     except ImportError:

--- a/pystuck/ipython.py
+++ b/pystuck/ipython.py
@@ -1,17 +1,57 @@
-import sys
+"""
+IPython shell wrapping
+"""
+from IPython.core.magic import (Magics, magics_class, line_magic)
 
-def ishell():
+
+def ishell(local_ns):
+    """Embed an IPython shell handing it the local namespace from
+    :var:`local_ns`.
+    """
+    banner = (
+        "Welcome to the pystuck interactive shell.\nUse the 'modules' dictionary "
+        "to access remote modules (like 'os', or '__main__')\nUse the `%show "
+        "threads` magic to display all thread stack traces.\n"
+    )
     try:
-        from IPython import embed
-        embed(user_ns=sys._getframe(1).f_locals)
-    except ImportError: 
-        # IPython < 0.11 
-        # Explicitly pass an empty list as arguments, because otherwise 
-        # IPython would use sys.argv from this script. 
-        try: 
+        from IPython.terminal.embed import InteractiveShellEmbed
+        ipshell = InteractiveShellEmbed(
+            banner1=banner)
+        ipshell.register_magics(IntrospectMagics)
+        ipshell(local_ns=local_ns)
+    except ImportError:
+        # IPython < 0.11
+        # Explicitly pass an empty list as arguments, because otherwise
+        # IPython would use sys.argv from this script.
+        try:
             from IPython.Shell import IPShellEmbed
-            ipshell = IPShellEmbed(argv=[], user_ns=sys._getframe(1).f_locals)
+            ipshell = IPShellEmbed(argv=[], user_ns=local_ns, banner1=banner)
+            ipshell.register_magics(IntrospectMagics)
             ipshell()
-        except ImportError: 
-            # IPython not found at all, raise ImportError 
-            raise 
+        except ImportError:
+            # IPython not found at all, raise ImportError
+            raise
+
+
+@magics_class
+class IntrospectMagics(Magics):
+    """Custom magics for thread inspection
+    """
+    @property
+    def modules(self):
+        '''Return the rpyc module namespace
+        '''
+        ns = self.shell.user_ns
+        return ns['modules']
+
+    @line_magic
+    def show(self, line):
+        """Show stack trace information from the remote Python process.
+        More subcommands are expected to be added in the near future.
+
+        Usage:
+
+            show threads : Print all thread backtraces to the console
+        """
+        if line == 'threads':
+            print(self.modules['pystuck.thread_probe'].stacks_repr())

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='pystuck',
       author='Alon Horev',
       author_email='alonho@gmail.com',
       packages=['pystuck'],
-      install_requires=['rpyc == 3.2.3', 'ipython'],
+      install_requires=['rpyc', 'ipython'],
       license='BSD',
       url='https://github.com/alonho/pystuck',
       entry_points={'console_scripts': ['pystuck=pystuck:main']})


### PR DESCRIPTION
I realize this is a bit much for a single commit so if you'd like me to break up the history a little better I'm happy to do so.

I adjusted the logic for the stack trace printing such that if a user specifies `--no-ipython` then the stacktraces are always printed but otherwise by default it's not. This way user can print it using the new `%show threads` `IPython` magic command if they want or just start messing with the `modules` / namespace stuff directly.

I think it would be good to extend the `%show` magic stuff to include the other goodies you might have in `thread_probe`. I haven't dug in far enough to know what's all in there.

If you have any quiffs I'm glad to get the code up to par with your expectations.
Thanks!