### PR TITLE
We don't support ipython 5.0, yet.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='pystuck',
       author='Alon Horev',
       author_email='alonho@gmail.com',
       packages=['pystuck'],
-      install_requires=['rpyc', 'ipython'],
+      install_requires=['rpyc', 'ipython<5.0'],
       license='BSD',
       url='https://github.com/alonho/pystuck',
       entry_points={'console_scripts': ['pystuck=pystuck:main']})


### PR DESCRIPTION
Pertains to #12.